### PR TITLE
Support Word Open XML Macro-Enabled Document.

### DIFF
--- a/src/kixi/mallet/boot.clj
+++ b/src/kixi/mallet/boot.clj
@@ -39,6 +39,7 @@
 
 (def text-extractors
   {".docx" word/docx->text
+   ".docm" word/docx->text
    ".pdf"  word/pdf->text
    ".doc"  word/doc->text
    ".xls"  word/xls->text})


### PR DESCRIPTION
Another type of word document. 
*.docm